### PR TITLE
Fix production deploy's ENV.fetch error

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ bundle exec whenever --update-crontab
     ``` bash
     sudo apt-get install build-essential libxml2-dev libxslt1-dev  libqtwebkit4  libqt4-dev xvfb libmysqlclient-dev freetds-dev
     ```
-1. Set `SERVER_USERNAME_IP` env variable. This is the target server IP address.
+1. Set `SERVER_IP` env variable. This is the target server IP address.
 1. Run `cap production deploy` 
 1. ssh into server and add .env from lastpass file into the `/home/rails/railsapps/care-4-kids-auto-notifier/shared` folder
 1. run `cap production deploy`
 
 ### Deploys after the inital deploy
-1. Set `SERVER_USERNAME_IP` env variable. This is the target server IP address.
+1. Set `SERVER_IP` env variable. This is the target server IP address.
 1. run `cap production deploy`
 
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -34,7 +34,7 @@ append :linked_files, ".env"
 # set :local_user, -> { `git config user.name`.chomp }
 
 # Default value for keep_releases is 5
-# set :keep_releases, 5
+set :keep_releases, 3
 
 # Uncomment the following to require manually verifying the host key before first deploy.
 # set :ssh_options, verify_host_key: :secure

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -4,7 +4,9 @@
 # You can define all roles on a single server, or split them:
 
 set :rvm_custom_path, '/usr/share/rvm'
-server ENV.fetch "SERVER_USERNAME_IP", user: "rails", roles: %w{app db web}
+set :stage, :production
+set :rails_env, :production
+server ENV.fetch("SERVER_IP"), user: "rails", roles: %w{app db web}
 # server "db.", user: "deploy", roles: %w{db}
 
 


### PR DESCRIPTION
First of all, the only reason I'm working at this hour is that I had to help out at home for the last hour of my day and I'm making that hour. It's not expected that anyone works these hours unless they have extenuating circumstances.  


When I was originally deploying the app I copied and pasted the actual IP address instead of using the `ENV.fetch`. I later inserted `ENV.fetch` to avoid including the actual IP address. 

I learned a very important lesson about the order of operations.
```
server ENV.fetch "SERVER_USERNAME_IP", user: "rails", roles: %w{app db web}
```
and
```
server ENV.fetch("SERVER_IP"), user: "rails", roles: %w{app db web}
```

result in very very different outcomes. The first evaluates the fetch first and inserts it in place. The second takes users and roles as arguments in fetch. It seems obvious but I totally missed it because both deploy. The first one uses roles; however, the second one doesn't use roles. The results are that when you don't use parentheses the app deploys but does not run migrations, delay_job, or whenever. 

... guess it's good that we deleted the entire setup and attempted to recreate from scratch.  

