### PR TITLE
DocumentAssignedEventsParser from DocumentAssignedEvents

### DIFF
--- a/app/parent_notifications/document_assigned_events_builder.rb
+++ b/app/parent_notifications/document_assigned_events_builder.rb
@@ -1,0 +1,64 @@
+DocumentAssignedEvent = Struct.new(:caseid, :type, :source, :date)
+
+class DocumentAssignedEventsBuilder
+    def self.parse_row(row)
+        DocumentAssignedEvent.new(
+            self.parse_client_id(row),
+            self.parse_doc_type(row), 
+            self.parse_source(row),
+            self.parse_datetime(row)
+        )
+    end
+
+    def self.parse_client_id(row)
+        raise InvalidDocuclassDataTypeError.new("Missing Key: ClientID") unless row.key?('ClientID')
+        row['ClientID']
+    end
+
+  def self.parse_doc_type(row)
+    raise InvalidDocuclassDataTypeError.new("Missing Key: DocType") unless row.key?('DocType')
+    doc_type = row['DocType']
+    # Handling both '-' and '–' due to character encoding mismatch
+    if (
+      ![
+        'RP - Redetermination',
+        'SP - Parent Supporting Document',
+        'PS - Provider Supporting Document',
+        'RP – Redetermination',
+        'SP – Parent Supporting Document',
+        'PS – Provider Supporting Document',
+      ].include?(doc_type)
+    ) then
+      raise InvalidDocuclassDataTypeError.new("Invalid DocType: #{doc_type}")
+    end
+
+    if doc_type.include?('-') then
+      doc_type_parts = doc_type.split(' - ')
+    else
+      doc_type_parts = doc_type.split(' – ')
+    end
+    doc_type_parts[1].downcase
+  end
+
+  def self.parse_source(row)
+    raise InvalidDocuclassDataTypeError.new("Missing Key: Source") unless row.key?('Source')
+    source = row['Source']
+    if (!['Fax', 'Emails', 'Scans'].include?(source))
+      raise InvalidDocuclassDataTypeError.new("Invalid Source: #{source}")
+    end
+    case source
+    when 'Fax'
+      'fax'
+    when 'Emails'
+      'web upload'
+    when 'Scans'
+      'mail'
+    end
+  end
+
+  def self.parse_datetime(row)
+    raise InvalidDocuclassDataTypeError.new("Missing Key: ArchivedAt") unless row.key?('ArchivedAt')
+    row['ArchivedAt']
+  end
+end
+

--- a/app/parent_notifications/document_assigned_events_builder.rb
+++ b/app/parent_notifications/document_assigned_events_builder.rb
@@ -1,22 +1,24 @@
 DocumentAssignedEvent = Struct.new(:caseid, :type, :source, :date)
 
 class DocumentAssignedEventsBuilder
-    def self.parse_row(row)
-        DocumentAssignedEvent.new(
-            self.parse_client_id(row),
-            self.parse_doc_type(row), 
-            self.parse_source(row),
-            self.parse_datetime(row)
-        )
-    end
+  def self.parse_row(row)
+    DocumentAssignedEvent.new(
+      self.parse_client_id(row),
+      self.parse_doc_type(row),
+      self.parse_source(row),
+      self.parse_datetime(row)
+    )
+  end
 
-    def self.parse_client_id(row)
-        raise InvalidDocuclassDataTypeError.new("Missing Key: ClientID") unless row.key?('ClientID')
-        row['ClientID']
-    end
+  def self.parse_client_id(row)
+    raise InvalidDocuclassDataTypeError.new("Missing Key: ClientID") unless row.key?('ClientID')
+
+    row['ClientID']
+  end
 
   def self.parse_doc_type(row)
     raise InvalidDocuclassDataTypeError.new("Missing Key: DocType") unless row.key?('DocType')
+
     doc_type = row['DocType']
     # Handling both '-' and '–' due to character encoding mismatch
     if (
@@ -42,10 +44,12 @@ class DocumentAssignedEventsBuilder
 
   def self.parse_source(row)
     raise InvalidDocuclassDataTypeError.new("Missing Key: Source") unless row.key?('Source')
+
     source = row['Source']
     if (!['Fax', 'Emails', 'Scans'].include?(source))
       raise InvalidDocuclassDataTypeError.new("Invalid Source: #{source}")
     end
+
     case source
     when 'Fax'
       'fax'
@@ -58,7 +62,7 @@ class DocumentAssignedEventsBuilder
 
   def self.parse_datetime(row)
     raise InvalidDocuclassDataTypeError.new("Missing Key: ArchivedAt") unless row.key?('ArchivedAt')
+
     row['ArchivedAt']
   end
 end
-

--- a/app/parent_notifications/document_assigned_events_repository.rb
+++ b/app/parent_notifications/document_assigned_events_repository.rb
@@ -2,7 +2,7 @@
 
 DocumentAssignedEvent = Struct.new(:caseid, :type, :source, :date)
 
-class DocumentAssignedEvents
+class DocumentAssignedEventsRepository
     @@client = TinyTds::Client.new(
       username: ENV.fetch('UNITEDWAYDB_USERNAME'),
       password: ENV.fetch('UNITEDWAYDB_PASSWORD'),

--- a/app/parent_notifications/document_assigned_events_repository.rb
+++ b/app/parent_notifications/document_assigned_events_repository.rb
@@ -51,62 +51,10 @@ class DocumentAssignedEventsRepository
 
   def self.build_event(row)
     begin
-      DocumentAssignedEvent.new(
-        parse_client_id_from_export(row),
-        parse_doc_type_from_export(row),
-        parse_source_from_export(row),
-        parse_datetime_from_export(row)
-      )
+      DocumentAssignedEventsBuilder.parse_row(row)
     rescue InvalidDocuclassDataTypeError => e
       Rails.logger.error e
       nil
     end
-  end
-
-  def self.parse_client_id_from_export(row)
-    row['ClientID']
-  end
-
-  def self.parse_doc_type_from_export(row)
-    doc_type = row['DocType']
-    # Handling both '-' and '–' due to character encoding mismatch
-    if (
-      ![
-        'RP - Redetermination',
-        'SP - Parent Supporting Document',
-        'PS - Provider Supporting Document',
-        'RP – Redetermination',
-        'SP – Parent Supporting Document',
-        'PS – Provider Supporting Document',
-      ].include?(doc_type)
-    ) then
-      raise InvalidDocuclassDataTypeError.new("Invalid DocType: #{doc_type}")
-    end
-
-    if doc_type.include?('-') then
-      doc_type_parts = doc_type.split(' - ')
-    else
-      doc_type_parts = doc_type.split(' – ')
-    end
-    doc_type_parts[1].downcase
-  end
-
-  def self.parse_source_from_export(row)
-    source = row['Source']
-    if (!['Fax', 'Emails', 'Scans'].include?(source))
-      raise InvalidDocuclassDataTypeError.new("Invalid Source: #{source}")
-    end
-    case source
-    when 'Fax'
-      'fax'
-    when 'Emails'
-      'web upload'
-    when 'Scans'
-      'mail'
-    end
-  end
-
-  def self.parse_datetime_from_export(row)
-    row['ArchivedAt']
   end
 end

--- a/app/parent_notifications/notification_generator.rb
+++ b/app/parent_notifications/notification_generator.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class NotificationGenerator
-  def initialize(document_assigned_events:)
-    @document_assigned_events = document_assigned_events
+  def initialize(document_assigned_events_repository:)
+    @document_assigned_events_repository = document_assigned_events_repository
   end
 
   def fetch_all_new
-    @document_assigned_events.fetch_all_new.each do |event|
+    @document_assigned_events_repository.fetch_all_new.each do |event|
       found_parent = Parent.where(caseid: event.caseid).first
       if parent_is_active(found_parent)
         yield build_notification_event(event: event)

--- a/app/parent_notifications/notification_runner.rb
+++ b/app/parent_notifications/notification_runner.rb
@@ -6,7 +6,7 @@ class NotificationRunner
             scheduler: scheduler
         )
         notification_generator = NotificationGenerator.new(
-            document_assigned_events: DocumentAssignedEvents
+            document_assigned_events_repository: DocumentAssignedEventsRepository
         )
         notification_manager = NotificationManager.new(
             message_queue: message_queue, notification_generator: notification_generator

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,5 +6,5 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-# Setup for DocumentAssignedEvents, prevents
+# Setup for DocumentAssignedEventsRepository, prevents
 EventCursor.create(key: 'document_assigned_event', time: Time.now)

--- a/docs/arch/application-flow_08-25-19.md
+++ b/docs/arch/application-flow_08-25-19.md
@@ -10,7 +10,7 @@ A central precept of testing is that one shouldn't test code they don't own.
 ## Decision
 The team decided to create three surfaces in which work would intergrate at two points: United Way Database <--> Notification Generation <--> Notification Transmission.
 
-The touch point between United Way Database and Notification Generator is the `DocumentAssignedEvents` class.
+The touch point between United Way Database and Notification Generator is the `DocumentAssignedEventsRepository` class.
 The touch point between Notification Generator and Notification Transmission is the `NotificationQueue` class.
 
 `ActiveJob` and the `Twilio` client are wrapped in singleton classes, `NotificationSendJob` and `TwilioSender`, respectively, to ensure testability.

--- a/spec/e2e/notification_runner_spec.rb
+++ b/spec/e2e/notification_runner_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Integration' do
     document_datetime = date + 1.minutes
     document_date = document_datetime.to_date
     document_time = document_datetime.strftime("%H:%M:%S")
-    lt = write_client.insert(
+     write_client.insert(
       doc_id: 1,
       typeId: SQLServerClient::FAX,
 
@@ -37,7 +37,7 @@ RSpec.describe 'Integration' do
       timeEntered: document_time,
     )
 
-    result = write_client.insert(
+    write_client.insert(
       doc_id: 2,
       typeId: SQLServerClient::EMAILS,
 
@@ -53,69 +53,19 @@ RSpec.describe 'Integration' do
       timeEntered: document_time
     )
 
-    result = write_client.insert(
-      doc_id: 3,
-      typeId: SQLServerClient::SCANS,
-
-      archivedAt: document_datetime,
-      deleted: nil,
-      client_id: case_id,
-      c17: '5551239876',
-      doc_type: 'RP - Redetermination',
-
-      instanceId: 3,
-
-      dateEntered: document_date,
-      timeEntered: document_time,
-    )
-
     Parent.create(caseid: case_id, cellphonenumber: cellphonenumber, active: true, notifications_generated_count: 1)
   end
 
-  context 'parent is active' do
-    it 'sends notifications' do
-      NotificationRunner.schedule_notifications(sender: FakeSender, scheduler: ImmediateScheduler)
-      expect(FakeSender.messages.size).to eq 3
-    end
-  end
-
-  context 'document received by fax' do
-    it 'message text is correctly formatted to use fax' do
-      NotificationRunner.schedule_notifications(sender: FakeSender, scheduler: ImmediateScheduler)
-      expect(FakeSender.messages[0]).to include(
-        <<-string.gsub(/\s+/, " ").strip
-          This is Care 4 Kids!
-          We have received your redetermination by fax on 01/01/2010.
-          You will be notified if there is any missing information.
-        string
-      )
-    end
-  end
-
-  context 'document received by email' do
-    it 'message text is correctly formatted to use web upload' do
-      NotificationRunner.schedule_notifications(sender: FakeSender, scheduler: ImmediateScheduler)
-      expect(FakeSender.messages[1]).to include(
-        <<-string.gsub(/\s+/, " ").strip
-          This is Care 4 Kids!
-          We have received your redetermination by web upload on 01/01/2010.
-          You will be notified if there is any missing information.
-        string
-      )
-    end
-  end
-
-  context 'document received by scan' do
-    it 'message text is correctly formatted to use mail' do
-      NotificationRunner.schedule_notifications(sender: FakeSender, scheduler: ImmediateScheduler)
-      expect(FakeSender.messages[2]).to include(
-        <<-string.gsub(/\s+/, " ").strip
-          This is Care 4 Kids!
-          We have received your redetermination by mail on 01/01/2010.
-          You will be notified if there is any missing information.
-        string
-      )
-    end
+  it 'sends notifications' do
+    NotificationRunner.schedule_notifications(sender: FakeSender, scheduler: ImmediateScheduler)
+    expect(FakeSender.messages.size).to eq 2
+    expect(FakeSender.messages[0]).to include(
+      <<-string.gsub(/\s+/, " ").strip
+        This is Care 4 Kids!
+        We have received your redetermination by fax on 01/01/2010.
+        You will be notified if there is any missing information.
+      string
+    )
   end
 
   after(:each) do

--- a/spec/parent_notifications/document_assigned_events_builder_spec.rb
+++ b/spec/parent_notifications/document_assigned_events_builder_spec.rb
@@ -1,0 +1,114 @@
+RSpec.describe DocumentAssignedEventsBuilder do
+    it 'extracts the client id' do
+        random_number = rand.i 
+        row = {
+            'ClientID'=> random_number,
+        'DocType'=> 'RP - Redetermination', 
+        'Source'=> 'Fax',
+         'ArchivedAt'=> Time.now.strftime('%Y-%m-%d %H:%M')
+        }
+        document_assigned_event = DocumentAssignedEventsBuilder.parse_row(row)
+        expect(document_assigned_event.caseid).to equal random_number
+    end
+
+    it 'extracts the archived at date' do
+        date = Time.now.strftime('%Y-%m-%d %H:%M')
+        row = {
+            'ClientID'=> 1,
+         'DocType'=> 'RP - Redetermination', 
+         'Source'=> 'Fax',
+          'ArchivedAt'=> date 
+        }
+        document_assigned_event = DocumentAssignedEventsBuilder.parse_row(row)
+        expect(document_assigned_event.date).to equal date
+    end
+
+    it 'raises error if all keys do not exist' do
+        date = Time.now.strftime('%Y-%m-%d %H:%M')
+        [
+            {
+                'DocType'=> 'RP - Redetermination', 
+                'Source'=> 'Fax',
+                'ArchivedAt'=> date 
+            },
+            {
+                'ClientID'=> 1,
+                'Source'=> 'Fax',
+                'ArchivedAt'=> date 
+            },
+            {
+                'ClientID'=> 1,
+                'DocType'=> 'RP - Redetermination', 
+                'ArchivedAt'=> date 
+            }, 
+            {
+                'ClientID'=> 1,
+                'DocType'=> 'RP - Redetermination', 
+                'Source'=> 'Fax',
+            }
+        ].each do |broken_row| 
+            expect { DocumentAssignedEventsBuilder.parse_row(broken_row) }.to raise_error InvalidDocuclassDataTypeError
+        end
+    end
+
+    context 'doc types' do 
+        it 'extracts and transforms all doc types' do
+            parsed_documents = [
+                    'RP - Redetermination',
+                    'SP - Parent Supporting Document',
+                    'PS - Provider Supporting Document',
+                    'RP – Redetermination',
+                    'SP – Parent Supporting Document',
+                    'PS – Provider Supporting Document',
+            ].map do |doc_type|
+                DocumentAssignedEventsBuilder.parse_row(
+                    {'ClientID'=> 1, 
+                    'DocType'=> doc_type,
+                     'Source'=> 'Fax', 
+                     'ArchivedAt' => Time.now.strftime('%Y-%m-%d %H:%M') 
+                     }
+                )
+            end
+            expect(parsed_documents.map(&:type)).to eq [
+                'redetermination',
+                'parent supporting document',
+                'provider supporting document',
+                'redetermination',
+                'parent supporting document',
+                'provider supporting document',
+            ]
+        end
+        it 'raises errors on invalid doc types' do 
+            random_number = rand.i 
+            row = {
+                'ClientID'=> random_number, 
+                'DocType'=> 'Invalid', 
+                'Source'=> 'Fax', 
+                'ArchivedAt'=> Time.now.strftime('%Y-%m-%d %H:%M')
+            }
+            expect { DocumentAssignedEventsBuilder.parse_row(row) }.to raise_error InvalidDocuclassDataTypeError
+        end
+    end 
+
+    context 'doc sources' do
+        it 'extracts and transforms all doc sources' do
+            parsed_documents = ['Fax', 'Emails', 'Scans'].map do |source|
+                DocumentAssignedEventsBuilder.parse_row(
+                    {'ClientID'=> 1, 'DocType'=> 'RP - Redetermination', 'Source'=> source, 'ArchivedAt' => Time.now.strftime('%Y-%m-%d %H:%M')  }
+                )
+            end
+            expect(parsed_documents.map(&:source)).to eq ['fax', 'web upload', 'mail']
+        end
+
+        it 'raises errors on invalid sources' do 
+            random_number = rand.i 
+            row = {
+                'ClientID'=> random_number, 
+                'DocType'=> 'RP - Redetermination',
+                'Source'=> 'Invalid', 
+                'ArchivedAt'=> Time.now.strftime('%Y-%m-%d %H:%M')
+            }
+            expect { DocumentAssignedEventsBuilder.parse_row(row) }.to raise_error InvalidDocuclassDataTypeError
+        end
+    end
+end

--- a/spec/parent_notifications/document_assigned_events_builder_spec.rb
+++ b/spec/parent_notifications/document_assigned_events_builder_spec.rb
@@ -1,114 +1,113 @@
 RSpec.describe DocumentAssignedEventsBuilder do
-    it 'extracts the client id' do
-        random_number = rand.i 
-        row = {
-            'ClientID'=> random_number,
-        'DocType'=> 'RP - Redetermination', 
-        'Source'=> 'Fax',
-         'ArchivedAt'=> Time.now.strftime('%Y-%m-%d %H:%M')
-        }
-        document_assigned_event = DocumentAssignedEventsBuilder.parse_row(row)
-        expect(document_assigned_event.caseid).to equal random_number
+  it 'extracts the client id' do
+    random_number = rand.i
+    row = {
+      'ClientID' => random_number,
+      'DocType' => 'RP - Redetermination',
+      'Source' => 'Fax',
+      'ArchivedAt' => Time.now.strftime('%Y-%m-%d %H:%M')
+    }
+    document_assigned_event = DocumentAssignedEventsBuilder.parse_row(row)
+    expect(document_assigned_event.caseid).to equal random_number
+  end
+
+  it 'extracts the archived at date' do
+    date = Time.now.strftime('%Y-%m-%d %H:%M')
+    row = {
+      'ClientID' => 1,
+      'DocType' => 'RP - Redetermination',
+      'Source' => 'Fax',
+      'ArchivedAt' => date
+    }
+    document_assigned_event = DocumentAssignedEventsBuilder.parse_row(row)
+    expect(document_assigned_event.date).to equal date
+  end
+
+  it 'raises error if all keys do not exist' do
+    date = Time.now.strftime('%Y-%m-%d %H:%M')
+    [
+      {
+        'DocType' => 'RP - Redetermination',
+        'Source' => 'Fax',
+        'ArchivedAt' => date
+      },
+      {
+        'ClientID' => 1,
+        'Source' => 'Fax',
+        'ArchivedAt' => date
+      },
+      {
+        'ClientID' => 1,
+        'DocType' => 'RP - Redetermination',
+        'ArchivedAt' => date
+      },
+      {
+        'ClientID' => 1,
+        'DocType' => 'RP - Redetermination',
+        'Source' => 'Fax',
+      }
+    ].each do |broken_row|
+      expect { DocumentAssignedEventsBuilder.parse_row(broken_row) }.to raise_error InvalidDocuclassDataTypeError
+    end
+  end
+
+  context 'doc types' do
+    it 'extracts and transforms all doc types' do
+      parsed_documents = [
+        'RP - Redetermination',
+        'SP - Parent Supporting Document',
+        'PS - Provider Supporting Document',
+        'RP – Redetermination',
+        'SP – Parent Supporting Document',
+        'PS – Provider Supporting Document',
+      ].map do |doc_type|
+        DocumentAssignedEventsBuilder.parse_row(
+          { 'ClientID' => 1,
+            'DocType' => doc_type,
+            'Source' => 'Fax',
+            'ArchivedAt' => Time.now.strftime('%Y-%m-%d %H:%M') }
+        )
+      end
+      expect(parsed_documents.map(&:type)).to eq [
+        'redetermination',
+        'parent supporting document',
+        'provider supporting document',
+        'redetermination',
+        'parent supporting document',
+        'provider supporting document',
+      ]
+    end
+    it 'raises errors on invalid doc types' do
+      random_number = rand.i
+      row = {
+        'ClientID' => random_number,
+        'DocType' => 'Invalid',
+        'Source' => 'Fax',
+        'ArchivedAt' => Time.now.strftime('%Y-%m-%d %H:%M')
+      }
+      expect { DocumentAssignedEventsBuilder.parse_row(row) }.to raise_error InvalidDocuclassDataTypeError
+    end
+  end
+
+  context 'doc sources' do
+    it 'extracts and transforms all doc sources' do
+      parsed_documents = ['Fax', 'Emails', 'Scans'].map do |source|
+        DocumentAssignedEventsBuilder.parse_row(
+          { 'ClientID' => 1, 'DocType' => 'RP - Redetermination', 'Source' => source, 'ArchivedAt' => Time.now.strftime('%Y-%m-%d %H:%M') }
+        )
+      end
+      expect(parsed_documents.map(&:source)).to eq ['fax', 'web upload', 'mail']
     end
 
-    it 'extracts the archived at date' do
-        date = Time.now.strftime('%Y-%m-%d %H:%M')
-        row = {
-            'ClientID'=> 1,
-         'DocType'=> 'RP - Redetermination', 
-         'Source'=> 'Fax',
-          'ArchivedAt'=> date 
-        }
-        document_assigned_event = DocumentAssignedEventsBuilder.parse_row(row)
-        expect(document_assigned_event.date).to equal date
+    it 'raises errors on invalid sources' do
+      random_number = rand.i
+      row = {
+        'ClientID' => random_number,
+        'DocType' => 'RP - Redetermination',
+        'Source' => 'Invalid',
+        'ArchivedAt' => Time.now.strftime('%Y-%m-%d %H:%M')
+      }
+      expect { DocumentAssignedEventsBuilder.parse_row(row) }.to raise_error InvalidDocuclassDataTypeError
     end
-
-    it 'raises error if all keys do not exist' do
-        date = Time.now.strftime('%Y-%m-%d %H:%M')
-        [
-            {
-                'DocType'=> 'RP - Redetermination', 
-                'Source'=> 'Fax',
-                'ArchivedAt'=> date 
-            },
-            {
-                'ClientID'=> 1,
-                'Source'=> 'Fax',
-                'ArchivedAt'=> date 
-            },
-            {
-                'ClientID'=> 1,
-                'DocType'=> 'RP - Redetermination', 
-                'ArchivedAt'=> date 
-            }, 
-            {
-                'ClientID'=> 1,
-                'DocType'=> 'RP - Redetermination', 
-                'Source'=> 'Fax',
-            }
-        ].each do |broken_row| 
-            expect { DocumentAssignedEventsBuilder.parse_row(broken_row) }.to raise_error InvalidDocuclassDataTypeError
-        end
-    end
-
-    context 'doc types' do 
-        it 'extracts and transforms all doc types' do
-            parsed_documents = [
-                    'RP - Redetermination',
-                    'SP - Parent Supporting Document',
-                    'PS - Provider Supporting Document',
-                    'RP – Redetermination',
-                    'SP – Parent Supporting Document',
-                    'PS – Provider Supporting Document',
-            ].map do |doc_type|
-                DocumentAssignedEventsBuilder.parse_row(
-                    {'ClientID'=> 1, 
-                    'DocType'=> doc_type,
-                     'Source'=> 'Fax', 
-                     'ArchivedAt' => Time.now.strftime('%Y-%m-%d %H:%M') 
-                     }
-                )
-            end
-            expect(parsed_documents.map(&:type)).to eq [
-                'redetermination',
-                'parent supporting document',
-                'provider supporting document',
-                'redetermination',
-                'parent supporting document',
-                'provider supporting document',
-            ]
-        end
-        it 'raises errors on invalid doc types' do 
-            random_number = rand.i 
-            row = {
-                'ClientID'=> random_number, 
-                'DocType'=> 'Invalid', 
-                'Source'=> 'Fax', 
-                'ArchivedAt'=> Time.now.strftime('%Y-%m-%d %H:%M')
-            }
-            expect { DocumentAssignedEventsBuilder.parse_row(row) }.to raise_error InvalidDocuclassDataTypeError
-        end
-    end 
-
-    context 'doc sources' do
-        it 'extracts and transforms all doc sources' do
-            parsed_documents = ['Fax', 'Emails', 'Scans'].map do |source|
-                DocumentAssignedEventsBuilder.parse_row(
-                    {'ClientID'=> 1, 'DocType'=> 'RP - Redetermination', 'Source'=> source, 'ArchivedAt' => Time.now.strftime('%Y-%m-%d %H:%M')  }
-                )
-            end
-            expect(parsed_documents.map(&:source)).to eq ['fax', 'web upload', 'mail']
-        end
-
-        it 'raises errors on invalid sources' do 
-            random_number = rand.i 
-            row = {
-                'ClientID'=> random_number, 
-                'DocType'=> 'RP - Redetermination',
-                'Source'=> 'Invalid', 
-                'ArchivedAt'=> Time.now.strftime('%Y-%m-%d %H:%M')
-            }
-            expect { DocumentAssignedEventsBuilder.parse_row(row) }.to raise_error InvalidDocuclassDataTypeError
-        end
-    end
+  end
 end

--- a/spec/parent_notifications/document_assigned_events_repository_spec.rb
+++ b/spec/parent_notifications/document_assigned_events_repository_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'sqlserver_helper'
 
-RSpec.describe DocumentAssignedEvents do
+RSpec.describe DocumentAssignedEventsRepository do
   before(:all) do
     @write_client = SQLServerClient.new
     @write_client.setup_types_table
@@ -17,7 +17,7 @@ RSpec.describe DocumentAssignedEvents do
   describe 'fetch_all_new' do
     context 'there are no events' do
       it 'returns nothing' do
-        expect(DocumentAssignedEvents.fetch_all_new.length).to eql 0
+        expect(DocumentAssignedEventsRepository.fetch_all_new.length).to eql 0
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe DocumentAssignedEvents do
           timeEntered: document_time,
         )
 
-        event = DocumentAssignedEvents.fetch_all_new.first
+        event = DocumentAssignedEventsRepository.fetch_all_new.first
         expect(event.caseid).to eql '1'
         expect(event.type).to eql 'redetermination'
         expect(event.source).to eql 'fax'
@@ -73,7 +73,7 @@ RSpec.describe DocumentAssignedEvents do
           timeEntered: document_time,
         )
 
-        expect(DocumentAssignedEvents.fetch_all_new.length).to eql 0
+        expect(DocumentAssignedEventsRepository.fetch_all_new.length).to eql 0
       end
 
       it 'does not fetch events that are marked as deleted in documents table' do
@@ -98,7 +98,7 @@ RSpec.describe DocumentAssignedEvents do
           timeEntered: document_time,
         )
 
-        expect(DocumentAssignedEvents.fetch_all_new.length).to eql 0
+        expect(DocumentAssignedEventsRepository.fetch_all_new.length).to eql 0
       end
 
       it 'does only fetch events that are faxes emails and scans in workflowsteps table' do
@@ -171,7 +171,7 @@ RSpec.describe DocumentAssignedEvents do
           timeEntered: document_time,
         )
 
-        expect(DocumentAssignedEvents.fetch_all_new.length).to eql 3
+        expect(DocumentAssignedEventsRepository.fetch_all_new.length).to eql 3
       end
     end
 
@@ -221,7 +221,7 @@ RSpec.describe DocumentAssignedEvents do
           timeEntered: later_future_time,
         )
 
-        expect(DocumentAssignedEvents.fetch_all_new.length).to eql 2
+        expect(DocumentAssignedEventsRepository.fetch_all_new.length).to eql 2
       end
     end
 
@@ -271,7 +271,7 @@ RSpec.describe DocumentAssignedEvents do
           timeEntered: earlier_time,
         )
 
-        expect(DocumentAssignedEvents.fetch_all_new.length).to eql 1
+        expect(DocumentAssignedEventsRepository.fetch_all_new.length).to eql 1
       end
 
       it 'does not fetch events again' do
@@ -330,8 +330,8 @@ RSpec.describe DocumentAssignedEvents do
           timeEntered: oldest_datetime.strftime("%H:%M:%S")
         )
 
-        expect(DocumentAssignedEvents.fetch_all_new.length).to eql 3
-        expect(DocumentAssignedEvents.fetch_all_new.length).to eql 0
+        expect(DocumentAssignedEventsRepository.fetch_all_new.length).to eql 3
+        expect(DocumentAssignedEventsRepository.fetch_all_new.length).to eql 0
       end
     end
   end
@@ -369,7 +369,7 @@ RSpec.describe DocumentAssignedEvents do
           timeEntered: document_time
         )
       end
-      expect(DocumentAssignedEvents.fetch_all_new.length).to eql counter
+      expect(DocumentAssignedEventsRepository.fetch_all_new.length).to eql counter
     end
   end
 
@@ -396,7 +396,7 @@ RSpec.describe DocumentAssignedEvents do
         timeEntered: document_time
       )
 
-      expect(DocumentAssignedEvents.fetch_all_new.length).to eql 0
+      expect(DocumentAssignedEventsRepository.fetch_all_new.length).to eql 0
     end
   end
 
@@ -423,7 +423,7 @@ RSpec.describe DocumentAssignedEvents do
         timeEntered: document_time
       )
 
-      expect(DocumentAssignedEvents.fetch_all_new.length).to eql 0
+      expect(DocumentAssignedEventsRepository.fetch_all_new.length).to eql 0
     end
   end
 end

--- a/spec/parent_notifications/document_assigned_events_repository_spec.rb
+++ b/spec/parent_notifications/document_assigned_events_repository_spec.rb
@@ -336,44 +336,7 @@ RSpec.describe DocumentAssignedEventsRepository do
     end
   end
 
-  context 'when an event has all database fields that are valid types' do
-    it 'returns the event' do
-      EventCursor.document_assigned_events_cursor = Time.now
-
-      counter = 0
-      document_datetime = Time.now + 1.minutes
-      document_date = document_datetime.to_date
-      document_time = document_datetime.strftime("%H:%M:%S")
-      [
-        'RP - Redetermination',
-        'SP - Parent Supporting Document',
-        'PS - Provider Supporting Document',
-        'RP – Redetermination',
-        'SP – Parent Supporting Document',
-        'PS – Provider Supporting Document',
-      ].each do |doc_type|
-        counter += 1
-        result = @write_client.insert(
-          doc_id: counter,
-          typeId: SQLServerClient::FAX,
-
-          archivedAt: document_datetime,
-          deleted: nil,
-          client_id: counter.to_s,
-          c17: '5551239876',
-          doc_type: doc_type,
-
-          instanceId: counter,
-
-          dateEntered: document_date,
-          timeEntered: document_time
-        )
-      end
-      expect(DocumentAssignedEventsRepository.fetch_all_new.length).to eql counter
-    end
-  end
-
-  context 'when an event has an invalid doc type type' do
+  context 'when an event has an invalid data' do
     it 'does not return the event' do
       EventCursor.document_assigned_events_cursor = Time.now
 
@@ -400,30 +363,4 @@ RSpec.describe DocumentAssignedEventsRepository do
     end
   end
 
-  context 'when an event has an invalid source type' do
-    it 'does not return the event' do
-      EventCursor.document_assigned_events_cursor = Time.now
-
-      document_datetime = Time.now + 1.minutes
-      document_date = document_datetime.to_date
-      document_time = document_datetime.strftime("%H:%M:%S")
-      result = @write_client.insert(
-        doc_id: 1,
-        typeId: SQLServerClient::INVALID,
-
-        archivedAt: document_datetime,
-        deleted: nil,
-        client_id: '1',
-        c17: '5551239876',
-        doc_type: 'RP - Redetermination',
-
-        instanceId: 1,
-
-        dateEntered: document_date,
-        timeEntered: document_time
-      )
-
-      expect(DocumentAssignedEventsRepository.fetch_all_new.length).to eql 0
-    end
-  end
 end

--- a/spec/parent_notifications/notification_generator_spec.rb
+++ b/spec/parent_notifications/notification_generator_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe NotificationGenerator do
       it 'returns a notification event with the correct case id' do
         time = Time.new(2010,1,1,0,0,0)
         caseid = (rand 100).to_s
-        document_assigned_events = build_document_assigned_events_stub(
+        document_assigned_events_repository= build_document_assigned_events_repo_stub(
           parents: [Parent.create(caseid: caseid, cellphonenumber: '+5555555555', active: true)],
           time: time
         )
 
-        notification_generator = NotificationGenerator.new document_assigned_events: document_assigned_events
+        notification_generator = NotificationGenerator.new document_assigned_events_repository: document_assigned_events_repository
 
         notification_events = fetch_all_new notification_generator
         expect(notification_events.first.caseid).to eql caseid
@@ -22,14 +22,14 @@ RSpec.describe NotificationGenerator do
       it 'returns a notification event with a notification id that is linked stored notification with message text' do
         time = Time.new(2010,1,1,0,0,0)
         caseid = (rand 100).to_s
-        document_assigned_events = build_document_assigned_events_stub(
+        document_assigned_events_repository= build_document_assigned_events_repo_stub(
           parents: [
             Parent.create(caseid: caseid, cellphonenumber: '+5555555555', active: true, notifications_generated_count: 1)
           ],
           time: time
         )
         notification_generator = NotificationGenerator.new(
-          document_assigned_events: document_assigned_events
+          document_assigned_events_repository: document_assigned_events_repository
         )
 
         notification_events = fetch_all_new notification_generator
@@ -40,14 +40,14 @@ RSpec.describe NotificationGenerator do
       it 'generates a message reminding the recipient of the instructions if they are receiving their first message' do
         caseid = (rand 100).to_s
         time = Time.new(2010,1,1,0,0,0)
-        document_assigned_events = build_document_assigned_events_stub(
+        document_assigned_events_repository= build_document_assigned_events_repo_stub(
           parents: [
             Parent.create(caseid: caseid, cellphonenumber: '+5555555555', active: true)
           ],
           time: time
         )
         notification_generator = NotificationGenerator.new(
-          document_assigned_events: document_assigned_events
+          document_assigned_events_repository: document_assigned_events_repository
         )
 
         notification_events = fetch_all_new notification_generator
@@ -58,32 +58,39 @@ RSpec.describe NotificationGenerator do
       it 'does not generate a message reminding the recipient of the instructions if they are not receiving their first message' do
         caseid = (rand 100).to_s
         time = Time.new(2010,1,1,0,0,0)
-        document_assigned_events = build_document_assigned_events_stub(
+        document_assigned_events_repository= build_document_assigned_events_repo_stub(
           parents: [
             Parent.create(caseid: caseid, cellphonenumber: '5555555555', active: true, notifications_generated_count: 1)
           ],
           time: time
         )
         notification_generator = NotificationGenerator.new(
-          document_assigned_events: document_assigned_events
+          document_assigned_events_repository: document_assigned_events_repository
         )
 
         notification_events = fetch_all_new notification_generator
         expect(notification_events.length).to eql 1
       end
+
+      describe 'message building' do
+        it 'correctly formats messages' do
+        end
+      
+      end
+
     end
 
     context 'there are multiple events that have corresponding active parents' do
       it 'returns all the notification events' do
         time = Time.new(2010,1,1,0,0,0)
-        document_assigned_events = build_document_assigned_events_stub(
+        document_assigned_events_repository= build_document_assigned_events_repo_stub(
           parents: [
             Parent.create(caseid: 'x', cellphonenumber: '+5555555555', active: true, notifications_generated_count: 1),
             Parent.create(caseid: 'y', cellphonenumber: '+5555555555', active: true, notifications_generated_count: 1)
           ],
           time: time
         )
-        notification_generator = NotificationGenerator.new document_assigned_events: document_assigned_events
+        notification_generator = NotificationGenerator.new document_assigned_events_repository: document_assigned_events_repository
 
         notification_events = fetch_all_new notification_generator
         expect(notification_events.length).to eql 2
@@ -97,12 +104,12 @@ RSpec.describe NotificationGenerator do
         parents = [
           Parent.create(caseid: 'y', cellphonenumber: '+5555555555', active: true, notifications_generated_count: 1)
         ]
-        document_assigned_events = build_document_assigned_events_stub(
+        document_assigned_events_repository= build_document_assigned_events_repo_stub(
           parents: parents,
           time: time
         )
 
-        notification_generator = NotificationGenerator.new document_assigned_events: document_assigned_events
+        notification_generator = NotificationGenerator.new document_assigned_events_repository: document_assigned_events_repository
 
         notification_events = fetch_all_new notification_generator
         expect(notification_events.length).to eql 1
@@ -113,12 +120,12 @@ RSpec.describe NotificationGenerator do
       it 'returns no notification events' do
         caseid = (rand 100).to_s
         time = Time.new(2010,1,1,0,0,0)
-        document_assigned_events = build_document_assigned_events_stub(
+        document_assigned_events_repository= build_document_assigned_events_repo_stub(
           parents: [Parent.create(caseid: caseid, cellphonenumber: '+5555555555', active: false)],
           time: time
         )
 
-        notification_generator = NotificationGenerator.new document_assigned_events: document_assigned_events
+        notification_generator = NotificationGenerator.new document_assigned_events_repository: document_assigned_events_repository
 
         notification_events = fetch_all_new notification_generator
         expect(notification_events.length).to eql 0
@@ -128,14 +135,14 @@ RSpec.describe NotificationGenerator do
     context 'there are multiple events that have corresponding inactive parents' do
       it 'returns no notification events' do
         time = Time.new(2010,1,1,0,0,0)
-        document_assigned_events = build_document_assigned_events_stub(
+        document_assigned_events_repository= build_document_assigned_events_repo_stub(
           parents: [
             Parent.create(caseid: 'x', cellphonenumber: '+5555555555', active: false),
             Parent.create(caseid: 'y', cellphonenumber: '+5555555555', active: false)
           ],
           time: time
         )
-        notification_generator = NotificationGenerator.new document_assigned_events: document_assigned_events
+        notification_generator = NotificationGenerator.new document_assigned_events_repository: document_assigned_events_repository
 
         notification_events = fetch_all_new notification_generator
         expect(notification_events.length).to eql 0
@@ -149,12 +156,12 @@ RSpec.describe NotificationGenerator do
         parents = [
           Parent.create(caseid: 'y', cellphonenumber: '+5555555555', active: true, notifications_generated_count: 1)
         ]
-        document_assigned_events = build_document_assigned_events_stub(
+        document_assigned_events_repository= build_document_assigned_events_repo_stub(
           parents: parents,
           time: time
         )
 
-        notification_generator = NotificationGenerator.new document_assigned_events: document_assigned_events
+        notification_generator = NotificationGenerator.new document_assigned_events_repository: document_assigned_events_repository
 
         notification_events = fetch_all_new notification_generator
         expect(notification_events.length).to eql 1
@@ -169,11 +176,11 @@ def fetch_all_new(notification_generator)
   notification_events
 end
 
-def build_document_assigned_events_stub(parents:, time:)
-  document_assigned_events = double
+def build_document_assigned_events_repo_stub(parents:, time:)
+  document_assigned_events_repository= double
   events = parents.map do |parent|
     DocumentAssignedEvent.new(parent.caseid, 'some doc', 'fax', time)
   end
-  allow(document_assigned_events).to receive(:fetch_all_new).and_return events
-  document_assigned_events
+  allow(document_assigned_events_repository).to receive(:fetch_all_new).and_return events
+  document_assigned_events_repository
 end

--- a/spec/parent_notifications/notification_generator_spec.rb
+++ b/spec/parent_notifications/notification_generator_spec.rb
@@ -71,13 +71,6 @@ RSpec.describe NotificationGenerator do
         notification_events = fetch_all_new notification_generator
         expect(notification_events.length).to eql 1
       end
-
-      describe 'message building' do
-        it 'correctly formats messages' do
-        end
-      
-      end
-
     end
 
     context 'there are multiple events that have corresponding active parents' do


### PR DESCRIPTION
- rename DocumentAssignedEvents to DocumentAssignedEventsRepository so the extraction makes more sense in terms of naming
- add tests to DocumentAssignedEventsRepository
- remove tests that don't add more information now that DocumentAssignedEventsRepository has been extracted and tested

For reference, this technique comes from one of my favorite programming books [Refactoring by Martin Fowler](https://martinfowler.com/books/refactoring.html)
For details on the specific technique:  [extract class](https://refactoring.guru/extract-class)
