### PR TITLE
Debug deployment permissions

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -25,5 +25,5 @@ every '0 19 * * *' do
 end
 
 every '40 12 * * 1-4' do
-  command 'cd && bash /home/rails/railsapps/care-4-kids-auto-notifier/current/scripts/automate_deployment'
+  command 'bash /home/rails/railsapps/care-4-kids-auto-notifier/current/scripts/automate_deployment'
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -25,5 +25,5 @@ every '0 19 * * *' do
 end
 
 every '40 12 * * 1-4' do
-  command 'scripts/automate_deployment'
+  command 'cd && bash /home/rails/railsapps/care-4-kids-auto-notifier/current/scripts/automate_deployment'
 end

--- a/scripts/automate_deployment
+++ b/scripts/automate_deployment
@@ -4,5 +4,4 @@ git clone https://github.com/ctoec/care-4-kids-auto-notifier.git /tmp/care-4-kid
 cd /tmp/care-4-kids-auto-notifier
 source /home/rails/railsapps/care-4-kids-auto-notifier/shared/.env
 SERVER_IP=$SERVER_IP SERVER_PASSWORD=$SERVER_PASSWORD RAILS_ENV=production cap production deploy --trace
-cd /tmp
 rm -rf /tmp/care-4-kids-auto-notifier


### PR DESCRIPTION
Not specifying the whole path meant that this didn't work in production.  Also removed an unnecessary command.